### PR TITLE
set http-max-response-time-ms to unlimited

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ CMD [ \
   "--http-server-address", "0.0.0.0:8888", \
   # Turn of host header validation since we are not running under a domain
   "--http-validate-host", "false", \
+  # Maximum time for processing a request, -1 for unlimited (eosio::http_plugin)
+  # Using unlimited here to avoid timeout_exception `deadline ${d} exceeded by ${t}us`
+  "--http-max-response-time-ms", "-1", \
   # Not 100% sure if needed - but also listed in https://developers.eos.io/welcome/latest/tutorials/bios-boot-sequence
   "--enable-stale-production", \
   # Set a producer name. Also not 100% sure if needed, but we want to produce blocks.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -14,7 +14,7 @@ set -e
     --abi-serializer-max-time-ms 10000 \
     --max-transaction-time 10000 \
     --enable-stale-production --producer-name eosio --plugin eosio::http_plugin \
-    --http-server-address 0.0.0.0:8888 --http-validate-host false &
+    --http-server-address 0.0.0.0:8888 --http-validate-host false --http-max-response-time-ms -1 &
 
 # Wait a bit for stability
 sleep 3


### PR DESCRIPTION
The default value was 30 which was causing problems, especially on M1 during smartcontract deployment.
That why turning off http max  response time in
eosio::http_plugin to avoid such problem in the future.